### PR TITLE
Added option to ignore EOF fifo and generates silence

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,19 @@ arecord.
 
 Here we are using the ALSA plughw feature.
 
+
 Scenario 5
+----------
+Live Stream resampling (to 32KHz) and encoding from FIFO and preparing for DAB muxer, with FIFO to odr-dabmux
+using mplayer. If there are no data in FIFO, encoder generates silence.
+
+    mplayer -quiet -loop 0 -af resample=32000:nowaveheader,format=s16le,channels=2 -ao pcm:file=/tmp/aac.fifo:fast <FILE/URL> &
+    dabplus-enc -l -f raw --fifo-silence -i /tmp/aac.fifo -r 32000 -c 2 -b 72 -o /dev/stdout \
+    mbuffer -q -m 10k -P 100 -s 1080 > station1.fifo
+
+*Note*: Do not use /dev/stdout for pcm oputput in mplayer. Mplayer log messages on stdout.
+
+Scenario 6
 ----------
 Wave file encoding, for non-realtime processing
 

--- a/src/FileInput.cpp
+++ b/src/FileInput.cpp
@@ -85,7 +85,7 @@ ssize_t FileInput::read(uint8_t* buf, size_t length)
             pcmread = length;
         }
         else {
-            fprintf(stderr, "Unable to read from input!\n");
+            //fprintf(stderr, "Unable to read from input!\n");
             return 0;
         }
     }


### PR DESCRIPTION
Hi,
This simple patch doesn't exit when reading form a a fifo if --fifo-silence flag is specified.
If there are no data in the fifo encoder will generate a silence. I think is better not interrupt the encoder process if the output is sent to odr-dabmux.

Sergio
