### PR TITLE
fifo silence bug fix

### DIFF
--- a/src/FileInput.cpp
+++ b/src/FileInput.cpp
@@ -96,6 +96,14 @@ ssize_t FileInput::read(uint8_t* buf, size_t length)
     return pcmread;
 }
 
+int FileInput::eof()
+{
+   int eof=feof(m_in_fh);
+   clearerr(m_in_fh);
+   return eof;
+}
+
+
 FileInput::~FileInput()
 {
     if (m_raw_input && m_in_fh) {

--- a/src/FileInput.h
+++ b/src/FileInput.h
@@ -45,6 +45,7 @@ class FileInput
          * Returns the number of bytes read.
          */
         ssize_t read(uint8_t* buf, size_t length);
+	int eof();
 
     protected:
         const char* m_filename;

--- a/src/dabplus-enc.cpp
+++ b/src/dabplus-enc.cpp
@@ -597,9 +597,10 @@ int main(int argc, char *argv[])
                 break;
             }
             else if (read != input_size) {
-                if (inFifoSilence && ((errno==EAGAIN)||(errno==0))) {
+                if (inFifoSilence && file_in.eof()) {
                    memset(input_buf, 0, input_size);
                    read = input_size;
+                   usleep((long int)input_size*1000000/(bytes_per_sample*channels*sample_rate));
                 } else {
                    fprintf(stderr, "Short file read !\n");
                    break;


### PR DESCRIPTION
Hi
this bug fix generates silence timing using sample rate, channels number and bytes per sample. Moreover does not use errno for error cheeking but feof.

Cheers
Sergio
