### PR TITLE
Fix bitrates over 144 kBit/s

### DIFF
--- a/libAACenc/src/aacenc_lib.cpp
+++ b/libAACenc/src/aacenc_lib.cpp
@@ -1361,8 +1361,10 @@ AACENC_ERROR aacEncOpen(
     }
 
     { /* Get bitstream outputbuffer size */
+      UINT buffer_bytes_min = (hAacEncoder->nMaxSubFrames*hAacEncoder->nMaxAacChannels*6144)>>3;
+      buffer_bytes_min = fixMax(buffer_bytes_min, (UINT) (24 * 110));   // consider maximum DAB+ Superframe size
       UINT ld_M;
-      for (ld_M=1; (UINT)(1<<ld_M) < (hAacEncoder->nMaxSubFrames*hAacEncoder->nMaxAacChannels*6144)>>3; ld_M++) ;
+      for (ld_M=1; (UINT)(1<<ld_M) < buffer_bytes_min; ld_M++) ;
       hAacEncoder->outBufferInBytes = (1<<ld_M);  /* buffer has to be 2^n */
     }
     hAacEncoder->outBuffer = GetRam_bsOutbuffer();


### PR DESCRIPTION
When the desired bitrate and therefore the size of the output Superframe was too high (over 144 kBit/s), the default output buffer size (with 2 channels: 2^11 = 2048 bytes) was exceeded. As the buffer write function applies a bitmask to the target address, silently a rollover occured and the function continued to (over)write at the start of the buffer. Thus the encoding output got unusable.

To fix this, consider the maximum allowed Superframe size (for 192 kBit/s) when the output buffer size is set.